### PR TITLE
support net.connect options parameter as object for creating and conn…

### DIFF
--- a/lib/socketserver.js
+++ b/lib/socketserver.js
@@ -39,6 +39,9 @@ SocketServer.prototype._makeServer = function() {
  */
 SocketServer.prototype._connect = function() {
 	this.net.connect(this.path, this._makeServer).on('error', function() {
+		if(typeof this.path == 'object')
+			return this._makeServer();
+	
 		this.fs.unlink(this.path, function() { // we don't care if there was an error
 			this._makeServer();
 		}.bind(this));


### PR DESCRIPTION
…ecting to a host and port

net.connect accepts other types of input such as a port or a host. by checking to see if the provided path is an object, we can keep your existing functionality, but allow for passing a configuration object with a port and a host so you can simply use telnet and the port -- or open a view into your realtime logs via a web browser.
